### PR TITLE
Disabled Google Translate by default

### DIFF
--- a/chrome_tixcraft.py
+++ b/chrome_tixcraft.py
@@ -433,7 +433,7 @@ def load_chromdriver_uc(webdriver_path, adblock_plus_enable, headless):
     options.add_argument("--no-sandbox");
 
     options.add_argument("--password-store=basic")
-    options.add_experimental_option("prefs", {"credentials_enable_service": False, "profile.password_manager_enabled": False})
+    options.add_experimental_option("prefs", {"credentials_enable_service": False, "profile.password_manager_enabled": False, "translate":{"enabled": False}})
 
     caps = options.to_capabilities()
     caps["unhandledPromptBehavior"] = u"accept"


### PR DESCRIPTION
當電腦作業系統語系跟購票網站語系不同時會跳出詢問是否要自動翻譯網站內容

這個修改是將 Chrome Driver 預設關閉翻譯網站的功能，讓畫面簡潔反應更迅速

<img width="1677" alt="image" src="https://github.com/max32002/tixcraft_bot/assets/4191668/4274f3d7-3cbc-4f5b-b03b-d48c0b7905c9">
