### PR TITLE
Update ocr solution for ticketplus

### DIFF
--- a/chrome_tixcraft.py
+++ b/chrome_tixcraft.py
@@ -9906,7 +9906,7 @@ def ticketplus_order(driver, config_dict, ocr, Captcha_Browser):
         if is_price_assign_by_bot:
             if config_dict["ocr_captcha"]["enable"]:
                 # OCR alway guess wrong answer, disable for now.
-                ticketplus_order_ocr(driver, config_dict, ocr, Captcha_Browser)
+                # ticketplus_order_ocr(driver, config_dict, ocr, Captcha_Browser)
                 pass
 
 def ticketplus_order_ocr(driver, config_dict, ocr, Captcha_Browser):


### PR DESCRIPTION
花了一點時間研究了ticketplus ocr的解決方案, 發現問題後用了一個挺簡單的方式來處理這個問題
我有測試過可以執行辨識了,相信蠻易讀的, 就停於此, 方便max做後續的開發
在這邊簡單寫一下原因跟解決的過程
首先主因是圖片格式的問題, 網站使用.svg的圖檔, 其實是有透明度的
只是因為渲染到網頁上有background color所以看不出來
轉成base64 image(jpg/png)後, 圖檔的透明度到了ddddocr引發問題
ddddocr應該對圖片進行了二值化/轉灰階之類的處理
所以辨識結果就很糟糕啦, 因為他根本看不清楚嘛
有時候會有漢字, 有時候length==1
solution就是把圖片丟到opencv裡面進行處理
加上白色背景之後再將新的圖檔轉為base64 value
接下來就可以交給ddddocr預測了

最後感謝Max開發這個好工具！