### PR TITLE
Always click input for OCR typing to speed up purchase flow for tixcraft.

### DIFF
--- a/chrome_tixcraft.py
+++ b/chrome_tixcraft.py
@@ -2682,9 +2682,6 @@ def tixcraft_keyin_captcha_code(driver, answer = "", auto_submit = False):
 
         if inputed_value is None:
             inputed_value = ""
-
-        if answer==inputed_value:
-            # no need to send key.
             is_visible = False
 
         if is_visible:


### PR DESCRIPTION
Hi Max大,

我看到 [issue64](https://github.com/max32002/tixcraft_bot/issues/64) 有遇到不會自動點擊驗證碼input的問題

我pull最新的code並使用tixcraft進行操作，我情境是 不啟用猜測驗證碼(config_dict["ocr_captcha"]["enable"] = false) 的情況下，程式就不會自動點擊驗證碼的input。
我發現在tixcraft_keyin_captcha_code中會去判斷 answer == input_value，因為未啟用猜測驗證碼，所以每次都會造成 is_visiable = false，導致不會點擊input。
詢問[issue64](https://github.com/max32002/tixcraft_bot/issues/64)也是這個情境，我覺得在不啟用猜驗證碼的情境下可以自動幫使用者點擊的話，就可以減少按tab或是點擊的動作，可以優化速度，記得比較久之前的版本也會自動點擊

我猜測原先的設計可能是以下幾點 
1. 避免answer是空白然後送出(現有架構len(answer) > 0 才會送)
2. 避免相同錯誤的驗證碼再重複送(若錯誤會clear input text)

最後這個 PR 主要是讓不管是有沒有啟用猜測驗證碼都可以點擊輸入驗證碼的input欄位，讓使用者在禁用的狀況下也可以自行輸入驗證碼並且按下enter就可以送出，而不用再按tab或是點擊input.

這個 PR 已在啟用和禁用猜測驗證碼的情況下進行測試。

請Max大再看看這個異動